### PR TITLE
Adjust hospitalisation data in ECDC script

### DIFF
--- a/code/auto_download/ecdc_download.r
+++ b/code/auto_download/ecdc_download.r
@@ -26,8 +26,8 @@ if (!dir.exists(ecdc_dir)) dir.create(ecdc_dir, recursive = TRUE)
 ecdc_hosp_filepath <- here("data-truth", "ECDC",
                       paste(file_base, "Hospitalizations.csv")) # covidHubUtils format
 
-R.utils::downloadFile(Sys.getenv("DATA_URL"), # Uses set environment variables
-                      ecdc_hosp_filepath,
+temp_ecdc <- R.utils::downloadFile(Sys.getenv("DATA_URL"), # Uses set environment variables
+                      tempfile(fileext = ".csv"),
                       username = Sys.getenv("DATA_USERNAME"),
                       password = Sys.getenv("DATA_PASSWORD"),
                       skip = FALSE,
@@ -35,11 +35,22 @@ R.utils::downloadFile(Sys.getenv("DATA_URL"), # Uses set environment variables
 
 public_sources <- c("Country_Website", "Country_API", "Country_Github")
 
-ecdc_hosp <- read_csv(ecdc_hosp_filepath) %>%
+ecdc_present <- read_csv(temp_ecdc) %>%
   filter(Indicator %in% c("New_Hospitalised") &
            Source %in% public_sources) %>%
   rename(location_name = CountryName) %>%
   mutate(target_variable = "inc hosp") %>%
   left_join(locations, by = "location_name") %>%
   select(date = Date, location, location_name, value = Value) %>%
-  write_csv(file = ecdc_hosp_filepath, append = FALSE)
+  group_by(location, location_name) %>%
+  summarise(tot_value = sum(value))
+
+ecdc_past <- read_csv(ecdc_hosp_filepath) %>%
+  group_by(location, location_name) %>%
+  summarise(old_tot_value = sum(value))
+
+ecdc_hosp <- full_join(ecdc_past, ecdc_present) %>%
+  mutate(value = tot_value - old_tot_value, .keep = "unused")
+
+write_csv(ecdc_hosp, file = ecdc_hosp_filepath, append = FALSE)
+

--- a/code/validation/adjust_hosps.R
+++ b/code/validation/adjust_hosps.R
@@ -1,0 +1,43 @@
+library(gh)
+library(purrr)
+
+get_all_versions <- function(file, gh_repo) {
+
+  gh(
+    "/repos/{gh_repo}/commits?path={file}",
+    gh_repo = gh_repo,
+    file = file
+  ) %>%
+    map_chr("sha") %>%
+    map_chr(~ glue::glue(
+      "https://raw.githubusercontent.com/{gh_repo}/{sha}/{file}",
+      gh_repo = gh_repo,
+      sha = .x,
+      file = file
+    )) %>%
+    map_chr(utils::URLencode)
+
+}
+
+all_hospdata_versions <- get_all_versions(
+  "data-truth/ECDC/truth_ECDC-Incident Hospitalizations.csv",
+  "epiforecasts/covid19-forecast-hub-europe"
+) %>%
+  map(readr::read_csv, show_col_types = FALSE, progress = FALSE)
+
+library(dplyr)
+adjusted_hospdata <- all_hospdata_versions %>%
+  map(group_by, location) %>%
+  map(arrange, date) %>%
+  map(mutate, cum_value = cumsum(value), .keep = "unused") %>%
+  map(filter, date == max(date)) %>%
+  bind_rows() %>%
+  distinct() %>%
+  arrange(location, date) %>%
+  mutate(value = cum_value - lag(cum_value), .keep = "unused")
+
+write_csv(
+  adjusted_hospdata,
+  "data-truth/ECDC/truth_ECDC-Incident Hospitalizations.csv"
+)
+

--- a/code/validation/adjust_hosps.R
+++ b/code/validation/adjust_hosps.R
@@ -41,6 +41,6 @@ adjusted_hospdata <- all_hospdata_versions %>%
 
 write_csv(
   adjusted_hospdata,
-  "data-truth/ECDC/truth_ECDC-Incident Hospitalizations.csv"
+  "data-truth/ECDC/corrected_truth_ECDC-Incident Hospitalizations.csv"
 )
 


### PR DESCRIPTION
Adjust hospitalisation data in ECDC script by pooling all new hospitalisations (no matter the date they are attributed to) and attributing them to current day.

Fix #941.

I still need to:

- [ ] investigate if something can be done about missing days