### PR TITLE
Do not include exact time in reports

### DIFF
--- a/code/validation/check_truth.py
+++ b/code/validation/check_truth.py
@@ -18,7 +18,7 @@ locations['JHU'] = pd.read_csv(here('./data-truth/JHU/truth_JHU-Incident Deaths.
 
 with open(here('./code/validation/check_truth.txt'), 'a', encoding='utf-8') as txtfile:
   
-    latest_check = 'Latest check of truth data: {}\n'.format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    latest_check = 'Latest check of truth data: {}\n'.format(datetime.now().strftime("%Y-%m-%d"))
     txtfile.write(latest_check + '\n')
 
     error_count = 0

--- a/data-truth/README.Rmd
+++ b/data-truth/README.Rmd
@@ -4,7 +4,7 @@ output: github_document
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE)
+knitr::opts_chunk$set(echo = FALSE, warning = FALSE)
 library(gh)
 library(dplyr)
 library(stringr)
@@ -27,7 +27,7 @@ Note there are some differences between the format of the JHU data and what we r
 
 #### Potential issues in the JHU dataset
 
-As at `r Sys.time()`
+As of `r Sys.Date()`
 
 ```{r issues, echo=FALSE, message=FALSE}
 


### PR DESCRIPTION
As to minimize conflicts if a workflow accidentally runs in a fork