### PR TITLE
specify minimum number of models in ensemble

### DIFF
--- a/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
+++ b/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
@@ -26,6 +26,7 @@ hub_ensemble <- run_ensemble(
   method = method,
   forecast_date = forecast_date,
   exclude_models = c(exclude_models, "EuroCOVIDhub-baseline"),
+  min_models = 3,
   return_criteria = TRUE
 )
 


### PR DESCRIPTION
This should probably be a config option but I'll leave it to @Bisaloo to decide that.