### PR TITLE
remove downloading of scraped data source

### DIFF
--- a/code/auto_download/hospitalisations-download.R
+++ b/code/auto_download/hospitalisations-download.R
@@ -6,7 +6,6 @@ script_dir <- here("code", "auto_download", "hospitalisations")
 
 # Download and save minimally processed data files
 source(here(script_dir, "get-ecdc-official.R"))
-source(here(script_dir, "get-ecdc-scraped.R"))
 source(here(script_dir, "get-owid.R"))
 source(here(script_dir, "get-non-eu.R"))
 


### PR DESCRIPTION
Downloading of hospitalisation data failed because the scraped data source can't be accessed. This removes downloading the scraped data sources for now (and it is not currently used anyway).