### PR TITLE
Update compile-model-reports.r

### DIFF
--- a/code/reports/compile-model-reports.r
+++ b/code/reports/compile-model-reports.r
@@ -18,7 +18,11 @@ library(EuroForecastHub)
 # Set parameters
 options(knitr.duplicate.label = "allow")
 
-report_date <- today()
+# Check the latest weekly evaluation
+eval_dates <- dir(here("evaluation", "weekly-summary"))
+eval_dates <- as.Date(gsub("(evaluation-)|(.csv)", "", eval_dates))
+
+report_date <- max(eval_dates)
 wday(report_date) <- get_hub_config("forecast_week_day")
 
 suppressWarnings(dir.create(here::here("html")))


### PR DESCRIPTION
Changes the file to run model reports so that reports default to the latest available evaluation, instead of the current week evaluation.

At the moment if there isn't a current evaluation csv, the model report building action [fails](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/runs/3874409066/jobs/6605567237#step:7:280).

This failure is redundant because we should see any failure to produce the weekly evaluation csv in the [scoring](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/workflows/scoring.yml) action.