### PR TITLE
Set actions to only run from this organisation

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   get_ecdc:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   get_jhu:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
     env:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"

--- a/.github/workflows/create-parquet.yml
+++ b/.github/workflows/create-parquet.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   create-parquet:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   ensemble:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -9,6 +9,7 @@ name: Render README
 
 jobs:
   render:
+    if: github.repository == 'covid19-forecast-hub-europe'
     name: Render README
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reports-country.yml
+++ b/.github/workflows/reports-country.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   country_reports:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reports-model.yml
+++ b/.github/workflows/reports-model.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   model_reports:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/scoring.yml
+++ b/.github/workflows/scoring.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 9 * * 0"
 jobs:
   scores:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visualisation.yml
+++ b/.github/workflows/visualisation.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   create-files:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zoltar-upload.yml
+++ b/.github/workflows/zoltar-upload.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We [continue](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/pull/2681) to have problems with Actions running on forks of the repo. These are difficult to control because it requires the fork owner to disable the actions. 

I suggest we add an if statement to all the Actions so they only run when our org (covid19-forecast-hub-europe) is the repo owner. (Following other people's experience of this [here](https://github.com/orgs/community/discussions/26704?sort=top))

Adding one example here then can copy to other actions if it seems like a good idea.