### PR TITLE
fix model reports

### DIFF
--- a/code/reports/compile-country-reports.r
+++ b/code/reports/compile-country-reports.r
@@ -17,6 +17,7 @@ wday(report_date) <- get_hub_config("forecast_week_day")
 suppressWarnings(dir.create(here::here("html")))
 
 for (country in c("Overall", hub_locations_ecdc$location_name)) {
+  message("Generating report for ", country)
   rmarkdown::render(here::here("code", "reports", "country",
                                "country-report.Rmd"),
                     output_format = "html_document",

--- a/code/reports/compile-model-reports.r
+++ b/code/reports/compile-model-reports.r
@@ -33,6 +33,7 @@ models <- list.files(
 
 # Create function for rendering report for each model
 render_report <- function(model) {
+  message("Generating report for ", model)
 	rmarkdown::render(here::here("code", "reports", "models",
                                "model-report.Rmd"),
                     params = list(model = model,

--- a/code/reports/rmdchunks/model-score-table.Rmd
+++ b/code/reports/rmdchunks/model-score-table.Rmd
@@ -32,7 +32,7 @@ if (nrow(model_df) > 0) {
       select(location_name, rel_ensemble_wis = rel_wis, rel_ensemble_ae = rel_ae)
     df <- model_df %>%
       select(location_name, rel_wis, rel_ae) %>%
-      inner_join(ensemble, by = "location_name") %>%
+      left_join(ensemble, by = "location_name") %>%
       pivot_longer(starts_with("rel")) %>%
       mutate(relative_to =
                if_else(grepl("ensemble", name), "ensemble", "baseline"),


### PR DESCRIPTION
Fixes a problem where model reports fail when ensembles don't exist for any of the countries covered by a model. This happens more often now that the criterion of only creating ensembles when the number of models is `>2` is enforced.

Also adds a couple of messages to make future debugging easier.