### PR TITLE
GH actions if clause

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   get_ecdc:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   get_jhu:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/create-parquet.yml
+++ b/.github/workflows/create-parquet.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   create-parquet:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ensemble:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -9,7 +9,7 @@ name: Render README
 
 jobs:
   render:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     name: Render README
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reports-country.yml
+++ b/.github/workflows/reports-country.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   country_reports:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reports-model.yml
+++ b/.github/workflows/reports-model.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   model_reports:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/scoring.yml
+++ b/.github/workflows/scoring.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 9 * * 0"
 jobs:
   scores:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visualisation.yml
+++ b/.github/workflows/visualisation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create-files:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zoltar-upload.yml
+++ b/.github/workflows/zoltar-upload.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Many actions are currently getting [skipped](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/workflows/JHU.yml), while others [still work](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/workflows/check-truth.yml). 

I think this was introduced by changes to Actions in #2699 . It should be fixed by this PR which switches to `if: github.repository_owner ==` rather than `if: github.repository ==` .

Should fix issues #2728 , #2633 , #2634 , #2630