### PR TITLE
update actions versions

### DIFF
--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ValidationV2.yml
+++ b/.github/workflows/ValidationV2.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: 'epiforecasts/covid19-forecast-hub-europe-validations'
 

--- a/.github/workflows/Validations-R.yml
+++ b/.github/workflows/Validations-R.yml
@@ -15,9 +15,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true

--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -14,7 +14,7 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/create-parquet.yml
+++ b/.github/workflows/create-parquet.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/hospitalisations.yml
+++ b/.github/workflows/hospitalisations.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: |
           echo "TODAY=$(date +%Y.%m.%d)" >> $GITHUB_ENV

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/reports-country.yml
+++ b/.github/workflows/reports-country.yml
@@ -17,9 +17,9 @@ jobs:
     if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
@@ -36,7 +36,7 @@ jobs:
       - name: Create country reports
         run: Rscript 'code/reports/compile-country-reports.r'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: github.event_name != 'pull_request'
         with:
           name: country-reports
@@ -44,7 +44,7 @@ jobs:
           path: |
             html/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         # If we are in a PR, we want to access the artifacts but we don't want
         # them to be used to build the site
         if: github.event_name == 'pull_request'

--- a/.github/workflows/reports-model.yml
+++ b/.github/workflows/reports-model.yml
@@ -17,9 +17,9 @@ jobs:
     if: github.repository_owner == 'covid19-forecast-hub-europe'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
@@ -36,7 +36,7 @@ jobs:
       - name: Create model reports
         run: Rscript 'code/reports/compile-model-reports.r'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: github.event_name != 'pull_request'
         with:
           name: model-reports
@@ -44,7 +44,7 @@ jobs:
           path: |
             html/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         # If we are in a PR, we want to access the artifacts but we don't want
         # them to be used to build the site
         if: github.event_name == 'pull_request'

--- a/.github/workflows/scoring.yml
+++ b/.github/workflows/scoring.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/submission_preview.yml
+++ b/.github/workflows/submission_preview.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true

--- a/.github/workflows/visualisation.yml
+++ b/.github/workflows/visualisation.yml
@@ -12,7 +12,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Python
       uses: actions/setup-python@v2

--- a/.github/workflows/zoltar-upload.yml
+++ b/.github/workflows/zoltar-upload.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive # zoltar upload relies on validations submodule
 


### PR DESCRIPTION
Updated versions for github actions, copying from @Bisaloo PR over in the [submissions repo](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe-submissions/pull/20/files). 

I think this is the fix for #2635 ([failing scores](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/runs/4102153348)).