### PR TITLE
rename target_end_date -> date in data

### DIFF
--- a/code/auto_download/hospitalisations/process-owid.r
+++ b/code/auto_download/hospitalisations/process-owid.r
@@ -170,8 +170,7 @@ df <- df |>
   dplyr::filter(date == max(date)) |>
   dplyr::ungroup() |>
   dplyr::select(
-    location_name, location, target_end_date = date, value, source,
-    snapshot_date, status
+    location_name, location, date, value, source, snapshot_date, status
   )
 
 readr::write_csv(

--- a/data-truth/OWID/README.Rmd
+++ b/data-truth/OWID/README.Rmd
@@ -5,8 +5,8 @@ output: github_document
 
 The files in this directory are listed below. For more details on these see also the [data-truth](..) directory.
 
-- `truth-OWID-Incident Hospitalizations.csv`: truth data set as weekly data, including data likely to be revised (see `status` column)
-- `truncated-OWID-Incident Hospitalizations.csv`: truth data set as weekly data, likely not to be revised substantially
+- `truth-OWID-Incident Hospitalizations.csv`: truth data set as weekly data, including data likely to be revised (see `status` column); the `date` column corresponds to the last date in each week.
+- `truncated-OWID-Incident Hospitalizations.csv`: truth data set as weekly data, likely not to be revised substantially; the `date` column corresponds to the last date in each week.
 - `recommended-cutoffs.csv`: estimated number of weeks to cut off unless able to correct for right truncation, as reflected in the `status` column of the data files
 - `snapshots`: daily snapshots of the weekly raw hospitalisation data. Values indicate the number of new hospitalisations on the day indicated and the 6 preceding dates according to national definitions.
 - `final`: daily snapshots of the final rwa hospitalisation data, where final status is assigned 28 days after the event. Values indicate the number of new hospitalisations on the day indicated and the 6 preceding dates according to national definitions.

--- a/data-truth/OWID/README.md
+++ b/data-truth/OWID/README.md
@@ -5,9 +5,11 @@ The files in this directory are listed below. For more details on these
 see also the [data-truth](..) directory.
 
 - `truth-OWID-Incident Hospitalizations.csv`: truth data set as weekly
-  data, including data likely to be revised (see `status` column)
+  data, including data likely to be revised (see `status` column); the
+  `date` column corresponds to the last date in each week.
 - `truncated-OWID-Incident Hospitalizations.csv`: truth data set as
-  weekly data, likely not to be revised substantially
+  weekly data, likely not to be revised substantially; the `date` column
+  corresponds to the last date in each week.
 - `recommended-cutoffs.csv`: estimated number of weeks to cut off unless
   able to correct for right truncation, as reflected in the `status`
   column of the data files

--- a/data-truth/OWID/truncated_OWID-Incident Hospitalizations.csv
+++ b/data-truth/OWID/truncated_OWID-Incident Hospitalizations.csv
@@ -1,4 +1,4 @@
-location_name,location,target_end_date,value,source,snapshot_date,status
+location_name,location,date,value,source,snapshot_date,status
 Belgium,BE,2020-03-21,1291,OWID,2022-07-18,final
 Belgium,BE,2020-03-28,3232,OWID,2022-07-18,final
 Belgium,BE,2020-04-04,3756,OWID,2022-07-18,final
@@ -1592,8 +1592,6 @@ Italy,IT,2023-01-14,2691,OWID,2023-02-11,final
 Italy,IT,2023-01-21,1935,OWID,2023-02-18,final
 Italy,IT,2023-01-28,1709,OWID,2023-02-25,final
 Italy,IT,2023-02-04,1582,OWID,2023-02-26,near final
-Italy,IT,2023-02-11,1406,OWID,2023-02-26,expecting revisions
-Italy,IT,2023-02-15,1243,OWID,2023-02-26,expecting revisions
 Latvia,LV,2020-01-06,0,OWID,2022-07-18,final
 Latvia,LV,2020-01-18,0,OWID,2022-07-18,final
 Latvia,LV,2020-02-12,0,OWID,2022-07-18,final

--- a/data-truth/OWID/truth_OWID-Incident Hospitalizations.csv
+++ b/data-truth/OWID/truth_OWID-Incident Hospitalizations.csv
@@ -1,4 +1,4 @@
-location_name,location,target_end_date,value,source,snapshot_date,status
+location_name,location,date,value,source,snapshot_date,status
 Belgium,BE,2020-03-21,1291,OWID,2022-07-18,final
 Belgium,BE,2020-03-28,3232,OWID,2022-07-18,final
 Belgium,BE,2020-04-04,3756,OWID,2022-07-18,final

--- a/data-truth/README.Rmd
+++ b/data-truth/README.Rmd
@@ -75,7 +75,7 @@ In the [final](OWID/final) directory we provide data that are considered "final"
 The files in this directory are the ones used for scoring the forecasts for their performance against observed data.
 
 The single dataset in [OWID/truth_OWID-Incident Hospitalizations.csv](OWID/truth_OWID-Incident Hospitalizations.csv) contains the latest data, where the final versions of the data are included for dates more than 28 days before the latest snapshot date, and the most recent version for any subsequent data.
-This is the dataset recommended for use in models that can take into account the truncation of the data. Please note that the data reported at weekly frequency has been shifted back one day to Saturday (instead of Sunday) in that file to comply with the Hub definition of an epidemiological week (Sunday-Saturday).
+This is the dataset recommended for use in models that can take into account the truncation of the data. Please note that the `date` field in this file corresponds to the final day of the week reported, and any data reported at weekly frequency has been shifted back one day to Saturday (instead of Sunday) in that file to comply with the Hub definition of an epidemiological week (Sunday-Saturday).
 
 We further provide a set of [recommended cutoffs](OWID/recommended-cutoffs.csv) for use with these data.
 These are estimates of the truncation in the number of weeks that should be cut off the data set if the aim is to have a data set that is not further revised by more than 5%.


### PR DESCRIPTION
I think target_end_date is clearer but this is currently breaking workflows.