### PR TITLE
Fix concurrency limitation in submission_preview.yml

### DIFF
--- a/.github/workflows/submission_preview.yml
+++ b/.github/workflows/submission_preview.yml
@@ -8,7 +8,7 @@ on:
       - 'data-processed/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
I am going through the docs for this feature again for another project and I think I figured out why pushes across different PR could sometimes cancel the workflow running in another PR.

Since `submission_preview.yml` is triggered by `pull_request_target`, `${{ github.ref }}` will always be `main`.