### PR TITLE
remove case/death download from ECDC website

### DIFF
--- a/.github/workflows/hospitalisations.yml
+++ b/.github/workflows/hospitalisations.yml
@@ -30,7 +30,6 @@ jobs:
         Rscript 'code/auto_download/hospitalisations-download.R'
         Rscript 'code/auto_download/hospitalisations/process-owid.r'
         Rscript 'code/auto_download/hospitalisations/check-revisions-owid.r'
-        Rscript 'code/auto_download/cases-deaths/get-ecdc-cases-deaths.R'
 
     - name: Commit files
       run: |


### PR DESCRIPTION
Removing as web site is timing out