### PR TITLE
designate baseline as secondary model

### DIFF
--- a/model-metadata/EuroCOVIDhub-baseline.yml
+++ b/model-metadata/EuroCOVIDhub-baseline.yml
@@ -6,7 +6,7 @@ model_contributors:
     email: hugo.gruson@lshtm.ac.uk
 website_url: https://covid19forecasthub.eu/
 license: cc-by-4.0
-team_model_designation: other
+team_model_designation: secondary
 methods: An baseline model against which other models can be evaluated
 team_funding: This model's development is funded by the European Centre for Disease
   Prevention and Control.


### PR DESCRIPTION
In other fields null models are included in ensembles where they have a regularising function. This seems a good idea here, too.